### PR TITLE
Disable OpenWRT procfs patch

### DIFF
--- a/configs/common/kernel
+++ b/configs/common/kernel
@@ -7,3 +7,6 @@ CONFIG_KERNEL_DEVMEM=y
 
 # Enable ACL on user's request
 CONFIG_USE_FS_ACL_ATTR=y
+
+# Don't strip procfiles
+CONFIG_KERNEL_PROC_STRIPPED=n

--- a/patches/openwrt/to-upstream/0031-config-Add-option-for-CONFIG_PROC_STRIPPED.patch
+++ b/patches/openwrt/to-upstream/0031-config-Add-option-for-CONFIG_PROC_STRIPPED.patch
@@ -1,0 +1,73 @@
+From 3aa0196aa7ed55463ba39139ad6789db7fc5b456 Mon Sep 17 00:00:00 2001
+From: Ben Kochie <superq@gmail.com>
+Date: Mon, 6 Apr 2020 10:23:41 +0200
+Subject: [PATCH] config: Add option for CONFIG_PROC_STRIPPED
+
+Allow downstream projects to configure the kernel
+CONFIG_PROC_STRIPPED patch.
+
+Signed-off-by: Ben Kochie <superq@gmail.com>
+---
+ config/Config-kernel.in          | 4 ++++
+ target/linux/generic/config-4.14 | 2 +-
+ target/linux/generic/config-4.19 | 2 +-
+ target/linux/generic/config-5.4  | 2 +-
+ 4 files changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/config/Config-kernel.in b/config/Config-kernel.in
+index fc24c3c932..47955f0bac 100644
+--- a/config/Config-kernel.in
++++ b/config/Config-kernel.in
+@@ -480,6 +480,10 @@ config KERNEL_PROC_VMCORE
+ config KERNEL_PROC_KCORE
+ 	bool
+ 
++config KERNEL_PROC_STRIPPED
++	bool "Strip extra proc files"
++	default y
++
+ config KERNEL_CRASH_DUMP
+ 	depends on i386 || x86_64 || arm || armeb
+ 	select KERNEL_KEXEC
+diff --git a/target/linux/generic/config-4.14 b/target/linux/generic/config-4.14
+index e42139744a..a4434c13c5 100644
+--- a/target/linux/generic/config-4.14
++++ b/target/linux/generic/config-4.14
+@@ -3656,7 +3656,7 @@ CONFIG_PRINT_STACK_DEPTH=64
+ CONFIG_PROC_FS=y
+ # CONFIG_PROC_KCORE is not set
+ # CONFIG_PROC_PAGE_MONITOR is not set
+-CONFIG_PROC_STRIPPED=y
++# CONFIG_PROC_STRIPPED is not set
+ CONFIG_PROC_SYSCTL=y
+ # CONFIG_PROFILE_ALL_BRANCHES is not set
+ # CONFIG_PROFILE_ANNOTATED_BRANCHES is not set
+diff --git a/target/linux/generic/config-4.19 b/target/linux/generic/config-4.19
+index 32209674ba..d710f4fabb 100644
+--- a/target/linux/generic/config-4.19
++++ b/target/linux/generic/config-4.19
+@@ -3865,7 +3865,7 @@ CONFIG_PRINT_STACK_DEPTH=64
+ CONFIG_PROC_FS=y
+ # CONFIG_PROC_KCORE is not set
+ # CONFIG_PROC_PAGE_MONITOR is not set
+-CONFIG_PROC_STRIPPED=y
++# CONFIG_PROC_STRIPPED is not set
+ CONFIG_PROC_SYSCTL=y
+ # CONFIG_PROC_VMCORE_DEVICE_DUMP is not set
+ # CONFIG_PROFILE_ALL_BRANCHES is not set
+diff --git a/target/linux/generic/config-5.4 b/target/linux/generic/config-5.4
+index b5deef31de..237f2f079f 100644
+--- a/target/linux/generic/config-5.4
++++ b/target/linux/generic/config-5.4
+@@ -4114,7 +4114,7 @@ CONFIG_PRINT_STACK_DEPTH=64
+ CONFIG_PROC_FS=y
+ # CONFIG_PROC_KCORE is not set
+ # CONFIG_PROC_PAGE_MONITOR is not set
+-CONFIG_PROC_STRIPPED=y
++# CONFIG_PROC_STRIPPED is not set
+ CONFIG_PROC_SYSCTL=y
+ # CONFIG_PROC_VMCORE_DEVICE_DUMP is not set
+ # CONFIG_PROFILE_ALL_BRANCHES is not set
+-- 
+2.17.1
+


### PR DESCRIPTION
Add patch to allow downstream projects to configure the kernel
CONFIG_PROC_STRIPPED patch.

Re-enable some `/proc` files disabled by default in OpenWRT[0]. This
enables several usefule proc files like `/proc/net/netstat` and
`/proc/net/snmp`.

[0]: https://git.openwrt.org/?p=openwrt/openwrt.git;a=blob;f=target/linux/generic/hack-4.14/902-debloat_proc.patch;h=c5f6397be1443db0130210b6685eccc77200a296;hb=refs/tags/v19.07.2

Signed-off-by: Ben Kochie <superq@gmail.com>